### PR TITLE
Refactor build-info to just use global constants.

### DIFF
--- a/generators/build-info/index.js
+++ b/generators/build-info/index.js
@@ -1,0 +1,12 @@
+
+var generators = require('yeoman-generator');
+var util = require('yeoman-util');
+
+module.exports = generators.Base.extend({
+	writing: {
+		config: util.copy(
+			'~config/webpack/partial/build-info.webpack.config.js',
+			'build-info.webpack.config.js'
+		)
+	}
+});


### PR DESCRIPTION
Easier this way for developers to structure the result in their app however they want. e.g.

``` javascript
/*global BUILD_COMMIT*/
var debug = {
    commit: BUILD_COMMIT
};
```
