### PR TITLE
Fix typo in `package.json` template

### DIFF
--- a/generators/app/templates/package.json5
+++ b/generators/app/templates/package.json5
@@ -7,7 +7,7 @@
 	"devDependencies": {
 		"webpack": "^1.9.11",
 		// For matching all the *.webpack.config.js files
-		"glob": "5^.0.10",
+		"glob": "^5.0.10",
 		// For ES6 support
 		"babel-core": "^5.5.6"
 	}


### PR DESCRIPTION
Was causing a lovely error

```
npm ERR! Darwin 14.5.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.2
npm ERR! npm  v2.13.4
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: glob@'5^.0.10'
npm ERR! notarget Valid install targets:
```
