### PR TITLE
Allow server-side entries and env URLs.

### DIFF
--- a/generators/entry/templates/entry.webpack.config.js
+++ b/generators/entry/templates/entry.webpack.config.js
@@ -17,8 +17,9 @@ const config = {
 	context: root,
 	// Output controls the settings for file generation.
 	output: {
+		<% if (target === 'node') { %>libraryTarget: 'commonjs2',<% }%>
 		filename: '<%=target === "node" ? "[name].js" : "[name].[hash].js"%>',
-		publicPath: '<%=target === "node" ? "/" : "/assets"%>',
+		<% if (target !== 'node') { %>publicPath: process.env['<%=name.toUpperCase()%>_URL'],<% }%>
 		path: path.join(root, 'build', '<%=name%>'),
 		chunkFilename: '[id].[hash].js'
 	}

--- a/generators/entry/templates/package.json5
+++ b/generators/entry/templates/package.json5
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
 		"find-nearest-file": "^1.0.0",
-		"webpack-partial": "^0.1.7"
+		"webpack-partial": "^0.1.8"
 	}
 }


### PR DESCRIPTION
For node projects make it so webpack exports commonjs2 modules, for web projects make sure `publicPath` is set correctly.
