### PR TITLE
Use correct vendor tooling depending on target.

### DIFF
--- a/generators/vendor/templates/vendor.webpack.config.js
+++ b/generators/vendor/templates/vendor.webpack.config.js
@@ -1,27 +1,24 @@
 
+import { optimize } from 'webpack';
 
-// See: http://clarkdave.net/2015/01/how-to-use-webpack-with-rails/
-import { optimize.CommonsChunkPlugin } from 'webpack';
-import fs from 'fs';
-
-export default function() {
-
-	const modules = fs.readdirSync('node_modules');
-
+export default function({ target, entry }) {
 	return {
-		entry: {
-
-			// The vendor entry is for grouping external libraries that are not
-			// likely to change, and thus can be packaged up separately from the
-			// main application code. This is handy for caching since the client
-			// won't have to re-download all the extra code.
-			vendor: modules
-		},
-
-		plugins: [
+		externals: target === 'node' ? [(context, request, cb) => {
+			cb();
+			// TODO: Externalize node vendor modules for server-side.
+			// cb(null, 'commonjs ' + request);
+		}] : [ ],
+		plugins: target !== 'node' ? [
 			// This performs the actual bundling of all the vendor files into their
 			// own package. See the vendor entry above for more info.
-			new CommonsChunkPlugin('vendor', '[name].[hash].js'),
-		]
+			new optimize.CommonsChunkPlugin({
+				name: 'vendor',
+				filename: '[name].[hash].js',
+				minChunks: (module) => {
+					return module.resource &&
+						module.resource.indexOf('node_modules') !== -1;
+				}
+			})
+		] : [ ]
 	};
 }


### PR DESCRIPTION
Since `node` vendor and `web` vendor bundles work differently. The `node` one still needs work.
