### PR TITLE
Add `root` partial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Sub-generators
  * json - JSON/JSON5 support.
  * postcss - Add support for postcss stylesheets.
  * progress - Show progress info as webpack build goes on.
+ * root - Make another folder act like `node_modules`.
  * sass - Add support for SASS stylesheets.
  * sharp - Image pre-processing with sharp.
  * source-maps - Add sensible source-map support.

--- a/generators/root/index.js
+++ b/generators/root/index.js
@@ -1,0 +1,12 @@
+
+var generators = require('yeoman-generator');
+var util = require('yeoman-util');
+
+module.exports = generators.Base.extend({
+  writing: {
+    config: util.copy(
+      '~config/webpack/partial/root.webpack.config.js',
+      'root.webpack.config.js'
+    ),
+  },
+});

--- a/generators/root/templates/root.webpack.config.js
+++ b/generators/root/templates/root.webpack.config.js
@@ -1,0 +1,12 @@
+
+import path from 'path';
+
+export default function root({ context }) {
+  return {
+    resolve: {
+      root: [
+        path.join(context, 'src'),
+      ],
+    },
+  };
+}


### PR DESCRIPTION
Handy for being able to include core parts of your app from anywhere. For example in tests one can do:

``` javascript
import Component from 'components/foo';
```

instead of:

``` javascript
import Component from '../../../src/components/foo';
```
