### PR TITLE
Allow es6 template strings in templates

### DIFF
--- a/generators/postcss/index.js
+++ b/generators/postcss/index.js
@@ -5,7 +5,8 @@ module.exports = util.Base.extend({
   writing: {
     config: util.copy(
       '~config/webpack/partial/postcss.webpack.config.js',
-      'postcss.webpack.config.js'
+      'postcss.webpack.config.js',
+      { interpolate: false }
     ),
     manifest: util.manifest(),
   },

--- a/generators/vendor/index.js
+++ b/generators/vendor/index.js
@@ -5,7 +5,8 @@ module.exports = util.Base.extend({
   writing: {
     config: util.copy(
       '~config/webpack/partial/vendor.webpack.config.js',
-      'vendor.webpack.config.js'
+      'vendor.webpack.config.js',
+      { interpolate: false }
     ),
   },
 });


### PR DESCRIPTION
`yeoman-util` uses `_.template()`, which uses the same delimeters as es6 template strings.

depends on https://github.com/izaakschroeder/yeoman-util/pull/15
closes https://github.com/izaakschroeder/generator-webpack/issues/27
closes https://github.com/izaakschroeder/generator-webpack/issues/25
