### PR TITLE
Add `OccurenceOrderPlugin` to entries.

### DIFF
--- a/generators/app/files/entry.webpack.config.js
+++ b/generators/app/files/entry.webpack.config.js
@@ -1,6 +1,7 @@
 
 import nearest from 'find-nearest-file';
 import path from 'path';
+import { optimize } from 'webpack';
 
 // No matter where we are, locate the canonical root of the project.
 const root = path.dirname(nearest('package.json'));
@@ -28,5 +29,8 @@ export default function({ target, name }) {
         publicPath: process.env[`${name.toUpperCase()}_URL`],
       }),
     },
+    plugins: [
+      new optimize.OccurenceOrderPlugin(true),
+    ],
   };
 }


### PR DESCRIPTION
Recommended for ordering the chunks consistently and in a manner that is conducive to loading the important bits first.
