### PR TITLE
Add `--bail` to build arguments.

### DIFF
--- a/generators/entry/templates/package.json5
+++ b/generators/entry/templates/package.json5
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build:${name}": "./node_modules/.bin/webpack --config config/webpack/${name}.webpack.config.babel.js"
+    "build:${name}": "./node_modules/.bin/webpack --bail --config config/webpack/${name}.webpack.config.babel.js"
   }
 }


### PR DESCRIPTION
This ensures the `webpack` process will actually terminate with an error code when an error occurs. Useful for ensuring CI and deployments actually fail when they should.
