### PR TITLE
Ensure the webpack runtime is isolated.

### DIFF
--- a/generators/vendor/files/package.json5
+++ b/generators/vendor/files/package.json5
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "runtime-webpack-plugin": "^0.1.0"
+  }
+}

--- a/generators/vendor/files/vendor.webpack.config.js
+++ b/generators/vendor/files/vendor.webpack.config.js
@@ -1,7 +1,22 @@
 
 import { optimize } from 'webpack';
+import RuntimePlugin from 'runtime-webpack-plugin';
 
-export default function({ target }) {
+function isEntry(module, entry) {
+  if (typeof entry === 'string') {
+    return module.resource.indexOf(entry) !== -1;
+  } else if (Array.isArray(entry)) {
+    return entry.some(item => isEntry(module, item));
+  }
+  return isEntry(module, Object.keys(entry).map(key => entry[key]));
+}
+
+function isExternal(module) {
+  return module.resource &&
+    module.resource.indexOf('node_modules') !== -1;
+}
+
+export default function({ target, entry }) {
   return {
     externals: target === 'node' ? [(context, request, cb) => {
 			// TODO: Make this work properly.
@@ -17,10 +32,10 @@ export default function({ target }) {
         name: 'vendor',
         filename: '[name].[hash].js',
         minChunks: (module) => {
-          return module.resource &&
-            module.resource.indexOf('node_modules') !== -1;
+          return isExternal(module) && !isEntry(module, entry);
         },
       }),
+      new RuntimePlugin('init'),
     ] : [ ],
   };
 }

--- a/generators/vendor/index.js
+++ b/generators/vendor/index.js
@@ -7,5 +7,6 @@ module.exports = util.Base.extend({
       'config/webpack/partial/vendor.webpack.config.js',
       'vendor.webpack.config.js'
     ),
+    manifest: util.manifest(),
   },
 });


### PR DESCRIPTION
Having the webpack runtime in its own file ensures that hash changes or module lists don't invalidate the entire vendor asset; it also ensures that only a small chunk of code is necessary to be placed in `head` if other modules need also be loaded in `head`.
